### PR TITLE
URLs seemed to be truncated

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ http://stackoverflow.com/editing-help#comment-formatting
 # Author: http://stackoverflow.com/users/1270695/ananda-mahto
 # http://chat.stackoverflow.com/transcript/message/11673110#11673110
 snarkments <- function(choice = "Reproduce and be merry") {
-  A <- c("Reproduce and be merry" = "Please provide a [minimal reproducible example](stackoverflow.com/questions/5963269/…), and please show us what you have tried",
-         "lmgtfy" = "I suppose you have [searched](meta.stackoverflow.com/help/how-to-ask) for your problem on SO?",
+  A <- c("Reproduce and be merry" = "Please provide a [minimal reproducible example](http://stackoverflow.com/q/5963269/1270695), and please show us what you have tried",
+         "lmgtfy" = "I suppose you have [searched](http://stackoverflow.com/help/how-to-ask) for your problem on SO?",
          "catkiller!" = "Die!!! Die!!! Die!!!")
   unname(A[choice])
 }
@@ -53,9 +53,9 @@ Usage:
 
 ```R
 snarkments()
-# [1] "Please provide a [minimal reproducible example](stackoverflow.com/questions/5963269/…), and please show us what you have tried"
+# [1] "Please provide a [minimal reproducible example](http://stackoverflow.com/q/5963269/1270695), and please show us what you have tried"
 snarkments("lmgtfy")
-# [1] "I suppose you have [searched](meta.stackoverflow.com/help/how-to-ask) for your problem on SO?"
+# [1] "I suppose you have [searched](http://stackoverflow.com/help/how-to-ask) for your problem on SO?"
 snarkments("catkiller!")
 # [1] "Die!!! Die!!! Die!!!"
 ```


### PR DESCRIPTION
They were showing without the http and had .... SO chat usually truncates URL display if it's beyond a certain length, it appears.
